### PR TITLE
Typo fix in AmazonS3ModuleImpl - replacing config key 'aws.access.sec…

### DIFF
--- a/src/main/java/com/zero_x_baadf00d/play/module/aws/s3/AmazonS3ModuleImpl.java
+++ b/src/main/java/com/zero_x_baadf00d/play/module/aws/s3/AmazonS3ModuleImpl.java
@@ -69,7 +69,7 @@ public class AmazonS3ModuleImpl implements AmazonS3Module {
     /**
      * @since 16.03.13
      */
-    private static final String AWS_SECRET_KEY = "aws.access.secret";
+    private static final String AWS_SECRET_KEY = "aws.secret.key";
 
     /**
      * Handle on the S3 API client.


### PR DESCRIPTION
…ret' with 'aws.secret.key'
